### PR TITLE
add imports and remove lubridate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,10 @@ Depends: R (>= 3.5.2)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
+Imports: dplyr,
+  purrr,
+  rlang,
+  tidyr
 Suggests: testthat, roxygen2, knitr
 RoxygenNote: 6.1.1
 URL: https://github.com/reconhub/followup


### PR DESCRIPTION
I've added the imports necessary to make sure this package can be installed. I've also removed `lubridate::as_date()` in favor of `as.Date()` because that was the only lubridate function being used. 